### PR TITLE
Fix inline mode leaving stale lines when content shrinks

### DIFF
--- a/app.go
+++ b/app.go
@@ -689,7 +689,7 @@ func (a *App) render() {
 
 	if a.inline {
 		// Inline mode: render at cursor position
-		a.linesUsed = a.screen.FlushInline(int(renderHeight))
+		a.linesUsed = a.screen.FlushInline(int(renderHeight), a.linesUsed)
 		a.pool.Swap() // Queue async clear
 	} else {
 		// Fullscreen mode

--- a/screen_test.go
+++ b/screen_test.go
@@ -1,0 +1,88 @@
+package glyph
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func newTestScreen(w, h int) (*Screen, *bytes.Buffer) {
+	var out bytes.Buffer
+	s := &Screen{
+		width:  w,
+		height: h,
+		back:   NewBuffer(w, h),
+		front:  NewBuffer(w, h),
+		buf:    bytes.Buffer{},
+		writer: &out,
+	}
+	return s, &out
+}
+
+func TestFlushInline(t *testing.T) {
+	t.Run("clears stale lines when content shrinks", func(t *testing.T) {
+		s, out := newTestScreen(40, 20)
+
+		// Frame 1: render 5 lines of content
+		for y := 0; y < 5; y++ {
+			for x := 0; x < 5; x++ {
+				s.back.Set(x, y, Cell{Rune: 'A', Style: DefaultStyle()})
+			}
+		}
+		lines1 := s.FlushInline(5, 0)
+		if lines1 != 5 {
+			t.Fatalf("expected 5 lines rendered, got %d", lines1)
+		}
+
+		// Frame 2: render only 2 lines (simulating a filter reducing results)
+		s.back.Clear()
+		for y := 0; y < 2; y++ {
+			for x := 0; x < 3; x++ {
+				s.back.Set(x, y, Cell{Rune: 'B', Style: DefaultStyle()})
+			}
+		}
+		out.Reset()
+		lines2 := s.FlushInline(2, lines1)
+		if lines2 != 2 {
+			t.Fatalf("expected 2 lines rendered, got %d", lines2)
+		}
+
+		// 2 for the content lines + 3 for the stale lines = 5 total
+		clearCount := strings.Count(out.String(), "\x1b[K")
+		if clearCount != 5 {
+			t.Errorf("expected 5 clear-line sequences (2 content + 3 stale), got %d", clearCount)
+		}
+	})
+
+	t.Run("cursor returns to first line after shrinking", func(t *testing.T) {
+		s, out := newTestScreen(40, 20)
+
+		// Frame 1: render 5 lines
+		for y := 0; y < 5; y++ {
+			for x := 0; x < 3; x++ {
+				s.back.Set(x, y, Cell{Rune: 'A', Style: DefaultStyle()})
+			}
+		}
+		s.FlushInline(5, 0)
+
+		// Frame 2: shrink to 2 lines
+		s.back.Clear()
+		for y := 0; y < 2; y++ {
+			for x := 0; x < 3; x++ {
+				s.back.Set(x, y, Cell{Rune: 'B', Style: DefaultStyle()})
+			}
+		}
+		out.Reset()
+		s.FlushInline(2, 5)
+
+		// Cursor must move up by max(2,5)-1 = 4 lines to return to line 0.
+		// A bug here would use linesRendered-1 = 1, leaving the cursor
+		// stranded 3 rows too low and causing subsequent frames to shift.
+		output := out.String()
+		moveUp4 := fmt.Sprintf("\x1b[%dA", 4)
+		if !strings.Contains(output, moveUp4) {
+			t.Errorf("expected cursor-up by 4 (%q) in output, got %q", moveUp4, output)
+		}
+	})
+}


### PR DESCRIPTION
@themastersheep :

## Fix inline mode leaving stale lines when content shrinks

When an inline app's visible content shrinks between frames (e.g. typing into a `FilterList` reduces matched items), the lines from the previous frame that are no longer covered by the new content were left on screen. This is because `FlushInline` only iterated up to the current content height, never clearing the rows below it.

### Root cause

`FlushInline` rendered lines `0..height-1` and then moved the cursor back up by `height-1`. When `height` decreased between frames (e.g. from 10 items to 3), lines 3-9 were never revisited — they remained in the terminal scrollback untouched.

Fullscreen mode doesn't have this problem because it operates on an alternate screen buffer with cell-level diffing. Cells that change from "content" to "empty" are detected as changes and overwritten. Inline mode has no persistent grid to diff against, so it must explicitly clear lines that are no longer needed.

### Fix

- `FlushInline` now accepts a `prevLines` parameter — the number of lines rendered in the previous frame.
- After rendering current content, it emits `\r\x1b[K` (clear-to-end-of-line) for each leftover line between `linesRendered` and `prevLines`.
- The cursor-up escape at the end uses `max(linesRendered, prevLines)` so the cursor returns to line 0 correctly.
- `app.go` passes `a.linesUsed` as `prevLines`, which naturally tracks the previous frame since the return value is stored back into it.

### Changes

- `screen.go` — `FlushInline(height, prevLines int)`: clear stale lines and fix cursor repositioning
- `app.go` — pass `a.linesUsed` to `FlushInline`
- `screen_test.go` — two new tests: stale line clearing and cursor repositioning after shrink

### No performance impact

Benchmarks are unchanged (within noise). The stale-line loop only executes when `prevLines > linesRendered`, so the steady-state path has zero overhead